### PR TITLE
Fix macOS compilation and fix main() return warning

### DIFF
--- a/SdlSc2k.h
+++ b/SdlSc2k.h
@@ -5,7 +5,7 @@
 #include<sys/types.h>
 #include<sys/stat.h>
 #include<fcntl.h>
-#if !defined(__APPLE__) && !defined(__MACH__)
+#if !defined(__APPLE__) || !defined(__MACH__)
 #include<malloc.h>
 #else
 #include<stdlib.h>

--- a/SdlSc2k.h
+++ b/SdlSc2k.h
@@ -5,7 +5,11 @@
 #include<sys/types.h>
 #include<sys/stat.h>
 #include<fcntl.h>
+#if !defined(__APPLE__) && !defined(__MACH__)
 #include<malloc.h>
+#else
+#include<stdlib.h>
+#endif
 #include<unistd.h>
 #include<string.h>
 

--- a/sc2kviewer.cpp
+++ b/sc2kviewer.cpp
@@ -93,4 +93,5 @@ int main(int argc, char **argv){
   delete sc;
   delete sd;
 
+  return 0;
 }


### PR DESCRIPTION
macOS doesn't have `malloc.h`.  It defines the `malloc()` function in `stdlib.h` instead, so this fixes that on Macs.

Also, I noticed that `main()` didn't always explicitly return a value, so this adds a `return 0` at the end of it.